### PR TITLE
Data printer 1.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,13 @@ Revision history for Perl extension {{$dist->name}}
 
 {{$NEXT}}
 
+1.112001  2011-07-19 21:02:33 Europe/Vienna
+    - added VERSION numbers
+
+1.112000  2011-07-19 20:30:08 Europe/Vienna
+    - converted the distribution back to EU::MM style
+    - doc fix for the Data::Printer plugin (thanks garu)
+
 1.111751  2011-06-24 23:54:05 Europe/Vienna
     - doc fix: don't mention nonexistent roles. :)
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,0 +1,28 @@
+Changes
+etc/perldb
+lib/DB/Pluggable.pm
+lib/DB/Pluggable/Plugin/BreakOnTestNumber.pm
+lib/DB/Pluggable/Plugin/DataPrinter.pm
+lib/DB/Pluggable/Plugin/TypeAhead.pm
+lib/DB/Pluggable/Role/AfterInit.pm
+lib/DB/Pluggable/Role/Eval.pm
+lib/DB/Pluggable/Role/Initializer.pm
+lib/DB/Pluggable/Role/WatchFunction.pm
+Makefile.PL
+MANIFEST			This list of files
+MANIFEST.SKIP
+README
+t/00-compile.t
+t/000-report-versions.t
+t/01_misc.t
+xt/critic.t
+xt/eol.t
+xt/no-tabs.t
+xt/perlcriticrc
+xt/pod-coverage.t
+xt/pod-spell.t
+xt/pod-syntax.t
+xt/synopsis.t
+xt/unused-vars.t
+META.yml                                 Module YAML meta-data (added by MakeMaker)
+META.json                                Module JSON meta-data (added by MakeMaker)

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,17 @@
+MYMETA.json
+MYMETA.yml
+MANIFEST.old
+^Makefile$
+^blib
+^pm_to_blib$
+^MakeMaker-\d
+cover_db
+t/000_standard__*
+Debian_CPANTS.txt
+nytprof.out
+~$
+\.git
+\.swp$
+\.tar$
+\.tar\.gz$
+^core$

--- a/META.json
+++ b/META.json
@@ -1,0 +1,47 @@
+{
+   "abstract" : "Add plugin support for the Perl debugger",
+   "author" : [
+      "Marcel Gruenauer <marcel@cpan.org>"
+   ],
+   "dynamic_config" : 1,
+   "generated_by" : "ExtUtils::MakeMaker version 6.58, CPAN::Meta::Converter version 2.110930",
+   "license" : [
+      "perl_5"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : "2"
+   },
+   "name" : "DB-Pluggable",
+   "no_index" : {
+      "directory" : [
+         "t",
+         "inc"
+      ]
+   },
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "ExtUtils::MakeMaker" : 0
+         }
+      },
+      "configure" : {
+         "requires" : {
+            "ExtUtils::MakeMaker" : "6.58"
+         }
+      },
+      "runtime" : {
+         "requires" : {
+            "Brickyard" : "1.111750",
+            "Brickyard::Accessor" : 0,
+            "Brickyard::Role::Plugin" : 0,
+            "Data::Printer" : 0,
+            "Hook::LexWrap" : 0,
+            "Role::Basic" : 0,
+            "Test::Builder" : 0
+         }
+      }
+   },
+   "release_status" : "stable",
+   "version" : "1.112001"
+}

--- a/META.json
+++ b/META.json
@@ -35,7 +35,7 @@
             "Brickyard" : "1.111750",
             "Brickyard::Accessor" : 0,
             "Brickyard::Role::Plugin" : 0,
-            "Data::Printer" : 0,
+            "Data::Printer" : "1.000001",
             "Hook::LexWrap" : 0,
             "Role::Basic" : 0,
             "Test::Builder" : 0

--- a/META.yml
+++ b/META.yml
@@ -21,7 +21,7 @@ requires:
   Brickyard: 1.111750
   Brickyard::Accessor: 0
   Brickyard::Role::Plugin: 0
-  Data::Printer: 0
+  Data::Printer: 1.000001
   Hook::LexWrap: 0
   Role::Basic: 0
   Test::Builder: 0

--- a/META.yml
+++ b/META.yml
@@ -1,0 +1,28 @@
+---
+abstract: 'Add plugin support for the Perl debugger'
+author:
+  - 'Marcel Gruenauer <marcel@cpan.org>'
+build_requires:
+  ExtUtils::MakeMaker: 0
+configure_requires:
+  ExtUtils::MakeMaker: 6.58
+dynamic_config: 1
+generated_by: 'ExtUtils::MakeMaker version 6.58, CPAN::Meta::Converter version 2.110930'
+license: perl
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: 1.4
+name: DB-Pluggable
+no_index:
+  directory:
+    - t
+    - inc
+requires:
+  Brickyard: 1.111750
+  Brickyard::Accessor: 0
+  Brickyard::Role::Plugin: 0
+  Data::Printer: 0
+  Hook::LexWrap: 0
+  Role::Basic: 0
+  Test::Builder: 0
+version: 1.112001

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,22 @@
+use strict;
+use warnings;
+use ExtUtils::MakeMaker 6.58;
+my $from = 'lib/DB/Pluggable.pm';
+WriteMakefile(
+    ABSTRACT_FROM      => $from,
+    AUTHOR             => 'Marcel Gruenauer <marcel@cpan.org>',
+    CONFIGURE_REQUIRES => { 'ExtUtils::MakeMaker' => '6.58' },
+    LICENSE            => 'perl',
+    NAME               => 'DB::Pluggable',
+    PREREQ_PM          => {
+        'Brickyard'               => '1.111750',
+        'Brickyard::Accessor'     => '0',
+        'Brickyard::Role::Plugin' => '0',
+        'Data::Printer'           => '0',
+        'Hook::LexWrap'           => '0',
+        'Role::Basic'             => '0',
+        'Test::Builder'           => '0'
+    },
+    VERSION_FROM => $from,
+    test         => { TESTS => 't/*.t' }
+);

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     DB::Pluggable - Add plugin support for the Perl debugger
 
 VERSION
-    version 1.111751
+    version 1.112001
 
 SYNOPSIS
         $ cat ~/.perldb
@@ -96,8 +96,8 @@ AVAILABILITY
     CPAN site near you, or see <http://search.cpan.org/dist/DB-Pluggable/>.
 
     The development version lives at
-    <http://github.com/hanekomu/DB-Pluggable> and may be cloned from
-    <git://github.com/hanekomu/DB-Pluggable.git>. Instead of sending
+    <https://github.com/garu/DB-Pluggable> and may be cloned from
+    <git://github.com/garu/DB-Pluggable.git>. Instead of sending
     patches, please fork this project using the standard git and github
     infrastructure.
 
@@ -105,7 +105,10 @@ AUTHOR
     Marcel Gruenauer <marcel@cpan.org>
 
 COPYRIGHT AND LICENSE
-    This software is copyright (c) 2008 by Marcel Gruenauer.
+    The following copyright notice applies to all the files provided in this
+    distribution, including binary files, unless explicitly noted otherwise.
+
+    This software is copyright (c) 2008-2011 by Marcel Gruenauer.
 
     This is free software; you can redistribute it and/or modify it under
     the same terms as the Perl 5 programming language system itself.

--- a/lib/DB/Pluggable.pm
+++ b/lib/DB/Pluggable.pm
@@ -70,12 +70,13 @@ my $DB_eval = \&DB::eval;
 
 =pod
 
-=for test_synopsis 1;
 __END__
 
 =head1 NAME
 
 DB::Pluggable - Add plugin support for the Perl debugger
+
+=for test_synopsis BEGIN { die "SKIP: Skipping the config file portion of synopsis...\n" };
 
 =head1 SYNOPSIS
 
@@ -93,7 +94,7 @@ DB::Pluggable - Add plugin support for the Perl debugger
     [DataPrinter]
     EOINI
 
-Then:
+    Then:
 
     $ perl -d foo.pl
 

--- a/lib/DB/Pluggable.pm
+++ b/lib/DB/Pluggable.pm
@@ -1,12 +1,10 @@
-use 5.010;
+package DB::Pluggable;
 use strict;
 use warnings;
-
-package DB::Pluggable;
-
-# ABSTRACT: Add plugin support for the Perl debugger
+use 5.010;
 use Brickyard::Accessor new => 1, rw => [qw(brickyard)];
 use Brickyard 1.111750;
+our $VERSION = '1.112001';
 
 sub run_with_config {
     my $file = $_[1];
@@ -70,13 +68,14 @@ my $DB_eval = \&DB::eval;
 };
 1;
 
-=begin :prelude
+=pod
 
-=for test_synopsis
-1;
+=for test_synopsis 1;
 __END__
 
-=end :prelude
+=head1 NAME
+
+DB::Pluggable - Add plugin support for the Perl debugger
 
 =head1 SYNOPSIS
 
@@ -108,6 +107,32 @@ that invokes the plugin mechanism.
 
 Plugins should live in the C<DB::Pluggable::Plugin::> namespace, like
 L<DB::Pluggable::Plugin::BreakOnTestNumber> does.
+
+=head1 METHODS
+
+=head2 run_with_config
+
+Convenience class method to create, initialize and run the plugin
+system with the given configuration file or scalar reference.
+
+=head2 plugins_with
+
+Like the method with the same name in L<Brickyard>.
+
+=head2 init_from_config
+
+Like the method with the same name in L<Brickyard>.
+
+=head2 enable_watchfunction
+
+Tells the debugger to call C<DB::watchfunction()>, which in turn
+calls the C<watchfunction()> method of all plugins that consume the
+C<-WatchFunction> role.
+
+=head2 run
+
+This method just calls the C<initialize()> method of all plugins that
+consume the C<-Initializer> role.
 
 =head1 Plugin Phases
 
@@ -145,26 +170,20 @@ introduced to make your command work.
 
 =back
 
-=method run_with_config
+=head1 AUTHOR
 
-Convenience class method to create, initialize and run the plugin
-system with the given configuration file or scalar reference.
+The following person is the author of all the files provided in
+this distribution unless explicitly noted otherwise.
 
-=method plugins_with
+Marcel Gruenauer <marcel@cpan.org>
 
-Like the method with the same name in L<Brickyard>.
+=head1 COPYRIGHT AND LICENSE
 
-=method init_from_config
+The following copyright notice applies to all the files provided in
+this distribution, including binary files, unless explicitly noted
+otherwise.
 
-Like the method with the same name in L<Brickyard>.
+This software is copyright (c) 2008-2011 by Marcel Gruenauer.
 
-=method enable_watchfunction
-
-Tells the debugger to call C<DB::watchfunction()>, which in turn
-calls the C<watchfunction()> method of all plugins that consume the
-C<-WatchFunction> role.
-
-=method run
-
-This method just calls the C<initialize()> method of all plugins that
-consume the C<-Initializer> role.
+This is free software; you can redistribute it and/or modify it under
+the same terms as the Perl 5 programming language system itself.

--- a/lib/DB/Pluggable/Plugin/BreakOnTestNumber.pm
+++ b/lib/DB/Pluggable/Plugin/BreakOnTestNumber.pm
@@ -1,10 +1,7 @@
-use 5.010;
+package DB::Pluggable::Plugin::BreakOnTestNumber;
 use strict;
 use warnings;
-
-package DB::Pluggable::Plugin::BreakOnTestNumber;
-
-# ABSTRACT: Debugger plugin to break on Test::Builder-based tests
+use 5.010;
 use Role::Basic;
 use Hook::LexWrap;
 use Test::Builder;    # preload so we can "safely" overwrite lock()
@@ -12,6 +9,7 @@ with qw(
   DB::Pluggable::Role::Initializer
   DB::Pluggable::Role::WatchFunction
 );
+our $VERSION = '1.112001';
 
 sub initialize {
     @DB::testbreak = ();
@@ -66,15 +64,16 @@ sub watchfunction {
 }
 1;
 
-=begin :prelude
+=pod
 
 =for stopwords watchfunction
 
-=for test_synopsis
-1;
+=for test_synopsis 1;
 __END__
 
-=end :prelude
+=head1 NAME
+
+DB::Pluggable::Plugin::BreakOnTestNumber - Debugger plugin to break on Test::Builder-based tests
 
 =head1 SYNOPSIS
 
@@ -104,7 +103,9 @@ breakpoints - with the ability to stop at a specific test number. Andy
 Armstrong had the idea and wrote the original code, see
 L<http://use.perl.org/~AndyArmstrong/journal/35792>.
 
-=method initialize
+=head1 METHODS
+
+=head2 initialize
 
 Sets up the command handler that checks whether the command is of
 the form C<b #12> or C<b #12, 34, ...>. If so, it sets breakpoints
@@ -119,7 +120,7 @@ detect that a test is about to be finished - see the source code of
 L<Test::Builder> for details. Yes, this is nasty. It also means that
 this plugin will break C<Test::Builder> when using threads.
 
-=method watchfunction
+=head2 watchfunction
 
 Checks the current test number from L<Test::Builder> and instructs the
 debugger to stop if an appropriate test number has been reached.

--- a/lib/DB/Pluggable/Plugin/DataPrinter.pm
+++ b/lib/DB/Pluggable/Plugin/DataPrinter.pm
@@ -1,13 +1,11 @@
-use 5.010;
+package DB::Pluggable::Plugin::DataPrinter;
 use strict;
 use warnings;
-
-package DB::Pluggable::Plugin::DataPrinter;
-
-# ABSTRACT: Debugger plugin to use Data::Printer
+use 5.010;
 use Role::Basic;
 use Data::Printer; # to make it a requirement
 with qw(DB::Pluggable::Role::Initializer);
+our $VERSION = '1.112001';
 
 sub initialize {
     no warnings 'once';
@@ -15,13 +13,14 @@ sub initialize {
 }
 1;
 
-=begin :prelude
+=pod
 
-=for test_synopsis
-1;
+=for test_synopsis 1;
 __END__
 
-=end :prelude
+=head1 NAME
+
+DB::Pluggable::Plugin::DataPrinter - Debugger plugin to use Data::Printer
 
 =head1 SYNOPSIS
 
@@ -29,7 +28,7 @@ __END__
 
     use DB::Pluggable;
     DB::Pluggable->run_with_config(\<<EOINI)
-    [BreakOnTestNumber]
+    [DataPrinter]
     EOINI
 
     $ perl -d foo.pl
@@ -39,11 +38,9 @@ __END__
 
     Enter h or `h h' for help, or `man perldebug' for more help.
 
-    1..9
+    DB<1> c  (or s, or n, or whatever)
     ...
-      DB<1> c
-      ...
-      DB<2> p %foo
+    DB<2> p %foo
 
 =head1 DESCRIPTION
 
@@ -51,6 +48,8 @@ This debugger plugin exposes L<Data::Printer>'s C<p> command to the
 debugger. Use the C<~/.dataprinter> file to control the output - see
 L<Data::Printer> for details.
 
-=method initialize
+=head1 METHODS
+
+=head2 initialize
 
 Defines a debugger alias for the C<p> command.

--- a/lib/DB/Pluggable/Plugin/DataPrinter.pm
+++ b/lib/DB/Pluggable/Plugin/DataPrinter.pm
@@ -8,8 +8,17 @@ with qw(DB::Pluggable::Role::Initializer);
 our $VERSION = '1.112001';
 
 sub initialize {
+    my ($self) = @_;
     no warnings 'once';
-    $DB::alias{p} = 's/^/use Data::Printer; /; eval $cmd';
+    my @options;
+    for my $opt (keys %{ $self }) {
+      next if $opt eq 'name';
+      next if ref( $self->{ $opt } );
+      push @options, "$opt => $self->{ $opt }";
+     }
+
+    my $options = @options ? ', ' . join( ', ', @options ) : '';
+    $DB::alias{p} = "s/^(.*)\$/Data::Printer::\$1$options/";
 }
 1;
 
@@ -27,8 +36,10 @@ DB::Pluggable::Plugin::DataPrinter - Debugger plugin to use Data::Printer
     $ cat ~/.perldb
 
     use DB::Pluggable;
-    DB::Pluggable->run_with_config(\<<EOINI)
+    DB::Pluggable->run_with_config( \<<EOINI );
     [DataPrinter]
+    output = 'stdout'
+    theme = Monokai
     EOINI
 
     $ perl -d foo.pl
@@ -45,7 +56,8 @@ DB::Pluggable::Plugin::DataPrinter - Debugger plugin to use Data::Printer
 =head1 DESCRIPTION
 
 This debugger plugin exposes L<Data::Printer>'s C<p> command to the
-debugger. Use the C<~/.dataprinter> file to control the output - see
+debugger. Use the C<~/.dataprinter> file to control the output, or
+add options to the [DataPrinter] section in .perldb - see
 L<Data::Printer> for details.
 
 =head1 METHODS

--- a/lib/DB/Pluggable/Plugin/TypeAhead.pm
+++ b/lib/DB/Pluggable/Plugin/TypeAhead.pm
@@ -1,13 +1,11 @@
-use 5.010;
+package DB::Pluggable::Plugin::TypeAhead;
 use strict;
 use warnings;
-
-package DB::Pluggable::Plugin::TypeAhead;
-
-# ABSTRACT: Debugger plugin to add type-ahead
+use 5.010;
 use Brickyard::Accessor rw => [qw(type ifenv)];
 use Role::Basic;
 with qw(DB::Pluggable::Role::AfterInit);
+our $VERSION = '1.112001';
 
 sub afterinit {
     my $self = shift;
@@ -23,15 +21,16 @@ sub afterinit {
 }
 1;
 
-=begin :prelude
+=pod
 
 =for stopwords typeahead afterinit
 
-=for test_synopsis
-1;
+=for test_synopsis 1;
 __END__
 
-=end :prelude
+=head1 NAME
+
+DB::Pluggable::Plugin::TypeAhead - Debugger plugin to add type-ahead
 
 =head1 SYNOPSIS
 
@@ -66,6 +65,8 @@ typeahead, you would run your program like this:
 The inspiration for this plugin came from Ovid's blog post at
 L<http://blogs.perl.org/users/ovid/2010/02/easier-test-debugging.html>.
 
-=method afterinit
+=head1 METHODS
+
+=head2 afterinit
 
 Pushes the commands to the debugger's typeahead.

--- a/lib/DB/Pluggable/Role/AfterInit.pm
+++ b/lib/DB/Pluggable/Role/AfterInit.pm
@@ -1,20 +1,20 @@
-use 5.010;
+package DB::Pluggable::Role::AfterInit;
 use strict;
 use warnings;
-
-package DB::Pluggable::Role::AfterInit;
-
-# ABSTRACT: Do something in the debugger's afterinit() function
+use 5.010;
 use Role::Basic;
 with qw(Brickyard::Role::Plugin);
 requires qw(afterinit);
+our $VERSION = '1.112001';
 1;
 
-=begin :prelude
+=pod
 
 =for stopwords afterinit
 
-=end :prelude
+=head1 NAME
+
+DB::Pluggable::Role::AfterInit - Do something in the debugger's afterinit() function
 
 =head1 IMPLEMENTING
 

--- a/lib/DB/Pluggable/Role/Eval.pm
+++ b/lib/DB/Pluggable/Role/Eval.pm
@@ -1,14 +1,18 @@
-use 5.010;
+package DB::Pluggable::Role::Eval;
 use strict;
 use warnings;
-
-package DB::Pluggable::Role::Eval;
-
-# ABSTRACT: Do something in the debugger's eval() function
+use 5.010;
 use Role::Basic;
 with qw(Brickyard::Role::Plugin);
 requires qw(eval);
+our $VERSION = '1.112001';
 1;
+
+=pod
+
+=head1 NAME
+
+DB::Pluggable::Role::Eval - Do something in the debugger's eval() function
 
 =head1 IMPLEMENTING
 

--- a/lib/DB/Pluggable/Role/Initializer.pm
+++ b/lib/DB/Pluggable/Role/Initializer.pm
@@ -1,14 +1,18 @@
-use 5.010;
+package DB::Pluggable::Role::Initializer;
 use strict;
 use warnings;
-
-package DB::Pluggable::Role::Initializer;
-
-# ABSTRACT: Something that initializes the plugin system
+use 5.010;
 use Role::Basic;
 with qw(Brickyard::Role::Plugin);
 requires qw(initialize);
+our $VERSION = '1.112001';
 1;
+
+=pod
+
+=head1 NAME
+
+DB::Pluggable::Role::Initializer - Something that initializes the plugin system
 
 =head1 IMPLEMENTING
 

--- a/lib/DB/Pluggable/Role/WatchFunction.pm
+++ b/lib/DB/Pluggable/Role/WatchFunction.pm
@@ -1,20 +1,20 @@
-use 5.010;
+package DB::Pluggable::Role::WatchFunction;
 use strict;
 use warnings;
-
-package DB::Pluggable::Role::WatchFunction;
-
-# ABSTRACT: Do something during the debugger's watchfunction()
+use 5.010;
 use Role::Basic;
 with qw(Brickyard::Role::Plugin);
 requires qw(watchfunction);
+our $VERSION = '1.112001';
 1;
 
-=begin :prelude
+=pod
 
 =for stopwords watchfunction
 
-=end :prelude
+=head1 NAME
+
+DB::Pluggable::Role::WatchFunction - Do something during the debugger's watchfunction()
 
 =head1 IMPLEMENTING
 

--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -1,0 +1,59 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+
+
+use File::Find;
+use File::Temp qw{ tempdir };
+
+my @modules;
+find(
+  sub {
+    return if $File::Find::name !~ /\.pm\z/;
+    my $found = $File::Find::name;
+    $found =~ s{^lib/}{};
+    $found =~ s{[/\\]}{::}g;
+    $found =~ s/\.pm$//;
+    # nothing to skip
+    push @modules, $found;
+  },
+  'lib',
+);
+
+my @scripts;
+if ( -d 'bin' ) {
+    find(
+      sub {
+        return unless -f;
+        my $found = $File::Find::name;
+        # nothing to skip
+        push @scripts, $found;
+      },
+      'bin',
+    );
+}
+
+my $plan = scalar(@modules) + scalar(@scripts);
+$plan ? (plan tests => $plan) : (plan skip_all => "no tests to run");
+
+{
+    # fake home for cpan-testers
+    # no fake requested ## local $ENV{HOME} = tempdir( CLEANUP => 1 );
+
+    like( qx{ $^X -Ilib -e "require $_; print '$_ ok'" }, qr/^\s*$_ ok/s, "$_ loaded ok" )
+        for sort @modules;
+
+    SKIP: {
+        eval "use Test::Script 1.05; 1;";
+        skip "Test::Script needed to test script compilation", scalar(@scripts) if $@;
+        foreach my $file ( @scripts ) {
+            my $script = $file;
+            $script =~ s!.*/!!;
+            script_compiles( $file, "$script script compiles" );
+        }
+    }
+}

--- a/t/000-report-versions.t
+++ b/t/000-report-versions.t
@@ -1,0 +1,447 @@
+#!perl
+use warnings;
+use strict;
+use Test::More 0.94;
+
+# Include a cut-down version of YAML::Tiny so we don't introduce unnecessary
+# dependencies ourselves.
+
+package Local::YAML::Tiny;
+
+use strict;
+use Carp 'croak';
+
+# UTF Support?
+sub HAVE_UTF8 () { $] >= 5.007003 }
+BEGIN {
+    if ( HAVE_UTF8 ) {
+        # The string eval helps hide this from Test::MinimumVersion
+        eval "require utf8;";
+        die "Failed to load UTF-8 support" if $@;
+    }
+
+    # Class structure
+    require 5.004;
+    $YAML::Tiny::VERSION   = '1.40';
+
+    # Error storage
+    $YAML::Tiny::errstr    = '';
+}
+
+# Printable characters for escapes
+my %UNESCAPES = (
+    z => "\x00", a => "\x07", t    => "\x09",
+    n => "\x0a", v => "\x0b", f    => "\x0c",
+    r => "\x0d", e => "\x1b", '\\' => '\\',
+);
+
+
+#####################################################################
+# Implementation
+
+# Create an empty YAML::Tiny object
+sub new {
+    my $class = shift;
+    bless [ @_ ], $class;
+}
+
+# Create an object from a file
+sub read {
+    my $class = ref $_[0] ? ref shift : shift;
+
+    # Check the file
+    my $file = shift or return $class->_error( 'You did not specify a file name' );
+    return $class->_error( "File '$file' does not exist" )              unless -e $file;
+    return $class->_error( "'$file' is a directory, not a file" )       unless -f _;
+    return $class->_error( "Insufficient permissions to read '$file'" ) unless -r _;
+
+    # Slurp in the file
+    local $/ = undef;
+    local *CFG;
+    unless ( open(CFG, $file) ) {
+        return $class->_error("Failed to open file '$file': $!");
+    }
+    my $contents = <CFG>;
+    unless ( close(CFG) ) {
+        return $class->_error("Failed to close file '$file': $!");
+    }
+
+    $class->read_string( $contents );
+}
+
+# Create an object from a string
+sub read_string {
+    my $class  = ref $_[0] ? ref shift : shift;
+    my $self   = bless [], $class;
+    my $string = $_[0];
+    unless ( defined $string ) {
+        return $self->_error("Did not provide a string to load");
+    }
+
+    # Byte order marks
+    # NOTE: Keeping this here to educate maintainers
+    # my %BOM = (
+    #     "\357\273\277" => 'UTF-8',
+    #     "\376\377"     => 'UTF-16BE',
+    #     "\377\376"     => 'UTF-16LE',
+    #     "\377\376\0\0" => 'UTF-32LE'
+    #     "\0\0\376\377" => 'UTF-32BE',
+    # );
+    if ( $string =~ /^(?:\376\377|\377\376|\377\376\0\0|\0\0\376\377)/ ) {
+        return $self->_error("Stream has a non UTF-8 BOM");
+    } else {
+        # Strip UTF-8 bom if found, we'll just ignore it
+        $string =~ s/^\357\273\277//;
+    }
+
+    # Try to decode as utf8
+    utf8::decode($string) if HAVE_UTF8;
+
+    # Check for some special cases
+    return $self unless length $string;
+    unless ( $string =~ /[\012\015]+\z/ ) {
+        return $self->_error("Stream does not end with newline character");
+    }
+
+    # Split the file into lines
+    my @lines = grep { ! /^\s*(?:\#.*)?\z/ }
+                split /(?:\015{1,2}\012|\015|\012)/, $string;
+
+    # Strip the initial YAML header
+    @lines and $lines[0] =~ /^\%YAML[: ][\d\.]+.*\z/ and shift @lines;
+
+    # A nibbling parser
+    while ( @lines ) {
+        # Do we have a document header?
+        if ( $lines[0] =~ /^---\s*(?:(.+)\s*)?\z/ ) {
+            # Handle scalar documents
+            shift @lines;
+            if ( defined $1 and $1 !~ /^(?:\#.+|\%YAML[: ][\d\.]+)\z/ ) {
+                push @$self, $self->_read_scalar( "$1", [ undef ], \@lines );
+                next;
+            }
+        }
+
+        if ( ! @lines or $lines[0] =~ /^(?:---|\.\.\.)/ ) {
+            # A naked document
+            push @$self, undef;
+            while ( @lines and $lines[0] !~ /^---/ ) {
+                shift @lines;
+            }
+
+        } elsif ( $lines[0] =~ /^\s*\-/ ) {
+            # An array at the root
+            my $document = [ ];
+            push @$self, $document;
+            $self->_read_array( $document, [ 0 ], \@lines );
+
+        } elsif ( $lines[0] =~ /^(\s*)\S/ ) {
+            # A hash at the root
+            my $document = { };
+            push @$self, $document;
+            $self->_read_hash( $document, [ length($1) ], \@lines );
+
+        } else {
+            croak("YAML::Tiny failed to classify the line '$lines[0]'");
+        }
+    }
+
+    $self;
+}
+
+# Deparse a scalar string to the actual scalar
+sub _read_scalar {
+    my ($self, $string, $indent, $lines) = @_;
+
+    # Trim trailing whitespace
+    $string =~ s/\s*\z//;
+
+    # Explitic null/undef
+    return undef if $string eq '~';
+
+    # Quotes
+    if ( $string =~ /^\'(.*?)\'\z/ ) {
+        return '' unless defined $1;
+        $string = $1;
+        $string =~ s/\'\'/\'/g;
+        return $string;
+    }
+    if ( $string =~ /^\"((?:\\.|[^\"])*)\"\z/ ) {
+        # Reusing the variable is a little ugly,
+        # but avoids a new variable and a string copy.
+        $string = $1;
+        $string =~ s/\\"/"/g;
+        $string =~ s/\\([never\\fartz]|x([0-9a-fA-F]{2}))/(length($1)>1)?pack("H2",$2):$UNESCAPES{$1}/gex;
+        return $string;
+    }
+
+    # Special cases
+    if ( $string =~ /^[\'\"!&]/ ) {
+        croak("YAML::Tiny does not support a feature in line '$lines->[0]'");
+    }
+    return {} if $string eq '{}';
+    return [] if $string eq '[]';
+
+    # Regular unquoted string
+    return $string unless $string =~ /^[>|]/;
+
+    # Error
+    croak("YAML::Tiny failed to find multi-line scalar content") unless @$lines;
+
+    # Check the indent depth
+    $lines->[0]   =~ /^(\s*)/;
+    $indent->[-1] = length("$1");
+    if ( defined $indent->[-2] and $indent->[-1] <= $indent->[-2] ) {
+        croak("YAML::Tiny found bad indenting in line '$lines->[0]'");
+    }
+
+    # Pull the lines
+    my @multiline = ();
+    while ( @$lines ) {
+        $lines->[0] =~ /^(\s*)/;
+        last unless length($1) >= $indent->[-1];
+        push @multiline, substr(shift(@$lines), length($1));
+    }
+
+    my $j = (substr($string, 0, 1) eq '>') ? ' ' : "\n";
+    my $t = (substr($string, 1, 1) eq '-') ? ''  : "\n";
+    return join( $j, @multiline ) . $t;
+}
+
+# Parse an array
+sub _read_array {
+    my ($self, $array, $indent, $lines) = @_;
+
+    while ( @$lines ) {
+        # Check for a new document
+        if ( $lines->[0] =~ /^(?:---|\.\.\.)/ ) {
+            while ( @$lines and $lines->[0] !~ /^---/ ) {
+                shift @$lines;
+            }
+            return 1;
+        }
+
+        # Check the indent level
+        $lines->[0] =~ /^(\s*)/;
+        if ( length($1) < $indent->[-1] ) {
+            return 1;
+        } elsif ( length($1) > $indent->[-1] ) {
+            croak("YAML::Tiny found bad indenting in line '$lines->[0]'");
+        }
+
+        if ( $lines->[0] =~ /^(\s*\-\s+)[^\'\"]\S*\s*:(?:\s+|$)/ ) {
+            # Inline nested hash
+            my $indent2 = length("$1");
+            $lines->[0] =~ s/-/ /;
+            push @$array, { };
+            $self->_read_hash( $array->[-1], [ @$indent, $indent2 ], $lines );
+
+        } elsif ( $lines->[0] =~ /^\s*\-(\s*)(.+?)\s*\z/ ) {
+            # Array entry with a value
+            shift @$lines;
+            push @$array, $self->_read_scalar( "$2", [ @$indent, undef ], $lines );
+
+        } elsif ( $lines->[0] =~ /^\s*\-\s*\z/ ) {
+            shift @$lines;
+            unless ( @$lines ) {
+                push @$array, undef;
+                return 1;
+            }
+            if ( $lines->[0] =~ /^(\s*)\-/ ) {
+                my $indent2 = length("$1");
+                if ( $indent->[-1] == $indent2 ) {
+                    # Null array entry
+                    push @$array, undef;
+                } else {
+                    # Naked indenter
+                    push @$array, [ ];
+                    $self->_read_array( $array->[-1], [ @$indent, $indent2 ], $lines );
+                }
+
+            } elsif ( $lines->[0] =~ /^(\s*)\S/ ) {
+                push @$array, { };
+                $self->_read_hash( $array->[-1], [ @$indent, length("$1") ], $lines );
+
+            } else {
+                croak("YAML::Tiny failed to classify line '$lines->[0]'");
+            }
+
+        } elsif ( defined $indent->[-2] and $indent->[-1] == $indent->[-2] ) {
+            # This is probably a structure like the following...
+            # ---
+            # foo:
+            # - list
+            # bar: value
+            #
+            # ... so lets return and let the hash parser handle it
+            return 1;
+
+        } else {
+            croak("YAML::Tiny failed to classify line '$lines->[0]'");
+        }
+    }
+
+    return 1;
+}
+
+# Parse an array
+sub _read_hash {
+    my ($self, $hash, $indent, $lines) = @_;
+
+    while ( @$lines ) {
+        # Check for a new document
+        if ( $lines->[0] =~ /^(?:---|\.\.\.)/ ) {
+            while ( @$lines and $lines->[0] !~ /^---/ ) {
+                shift @$lines;
+            }
+            return 1;
+        }
+
+        # Check the indent level
+        $lines->[0] =~ /^(\s*)/;
+        if ( length($1) < $indent->[-1] ) {
+            return 1;
+        } elsif ( length($1) > $indent->[-1] ) {
+            croak("YAML::Tiny found bad indenting in line '$lines->[0]'");
+        }
+
+        # Get the key
+        unless ( $lines->[0] =~ s/^\s*([^\'\" ][^\n]*?)\s*:(\s+|$)// ) {
+            if ( $lines->[0] =~ /^\s*[?\'\"]/ ) {
+                croak("YAML::Tiny does not support a feature in line '$lines->[0]'");
+            }
+            croak("YAML::Tiny failed to classify line '$lines->[0]'");
+        }
+        my $key = $1;
+
+        # Do we have a value?
+        if ( length $lines->[0] ) {
+            # Yes
+            $hash->{$key} = $self->_read_scalar( shift(@$lines), [ @$indent, undef ], $lines );
+        } else {
+            # An indent
+            shift @$lines;
+            unless ( @$lines ) {
+                $hash->{$key} = undef;
+                return 1;
+            }
+            if ( $lines->[0] =~ /^(\s*)-/ ) {
+                $hash->{$key} = [];
+                $self->_read_array( $hash->{$key}, [ @$indent, length($1) ], $lines );
+            } elsif ( $lines->[0] =~ /^(\s*)./ ) {
+                my $indent2 = length("$1");
+                if ( $indent->[-1] >= $indent2 ) {
+                    # Null hash entry
+                    $hash->{$key} = undef;
+                } else {
+                    $hash->{$key} = {};
+                    $self->_read_hash( $hash->{$key}, [ @$indent, length($1) ], $lines );
+                }
+            }
+        }
+    }
+
+    return 1;
+}
+
+# Set error
+sub _error {
+    $YAML::Tiny::errstr = $_[1];
+    undef;
+}
+
+# Retrieve error
+sub errstr {
+    $YAML::Tiny::errstr;
+}
+
+
+
+#####################################################################
+# Use Scalar::Util if possible, otherwise emulate it
+
+BEGIN {
+    eval {
+        require Scalar::Util;
+    };
+    if ( $@ ) {
+        # Failed to load Scalar::Util
+        eval <<'END_PERL';
+sub refaddr {
+    my $pkg = ref($_[0]) or return undef;
+    if (!!UNIVERSAL::can($_[0], 'can')) {
+        bless $_[0], 'Scalar::Util::Fake';
+    } else {
+        $pkg = undef;
+    }
+    "$_[0]" =~ /0x(\w+)/;
+    my $i = do { local $^W; hex $1 };
+    bless $_[0], $pkg if defined $pkg;
+    $i;
+}
+END_PERL
+    } else {
+        Scalar::Util->import('refaddr');
+    }
+}
+
+
+#####################################################################
+# main test
+#####################################################################
+
+package main;
+
+BEGIN {
+
+    # Skip modules that either don't want to be loaded directly, such as
+    # Module::Install, or that mess with the test count, such as the Test::*
+    # modules listed here.
+    #
+    # Moose::Role conflicts if Moose is loaded as well, but Moose::Role is in
+    # the Moose distribution and it's certain that someone who uses
+    # Moose::Role also uses Moose somewhere, so if we disallow Moose::Role,
+    # we'll still get the relevant version number.
+
+    my %skip = map { $_ => 1 } qw(
+      App::FatPacker
+      Class::Accessor::Classy
+      Devel::Cover
+      Module::Install
+      Moose::Role
+      POE::Loop::Tk
+      Template::Test
+      Test::Kwalitee
+      Test::Pod::Coverage
+      Test::Portability::Files
+      Test::YAML::Meta
+      open
+    );
+
+    my $Test = Test::Builder->new;
+
+    $Test->plan(skip_all => "MYMETA.yml could not be found")
+        unless -f 'MYMETA.yml' and -r _;
+
+    my $meta = (Local::YAML::Tiny->read('MYMETA.yml'))->[0];
+    my %requires;
+    for my $require_key (grep { /requires/ } keys %$meta) {
+        my %h = %{ $meta->{$require_key} };
+        $requires{$_}++ for keys %h;
+    }
+    delete $requires{perl};
+
+    diag("Testing with Perl $], $^X");
+    for my $module (sort keys %requires) {
+        if ($skip{$module}) {
+            note "$module doesn't want to be loaded directly, skipping";
+            next;
+        }
+        local $SIG{__WARN__} = sub { note "$module: $_[0]" };
+        require_ok $module or BAIL_OUT("can't load $module");
+        my $version = $module->VERSION;
+        $version = 'undefined' unless defined $version;
+        diag("    $module version is $version");
+    }
+    done_testing;
+}

--- a/xt/critic.t
+++ b/xt/critic.t
@@ -1,0 +1,9 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+# use English qw(-no_match_vars);
+eval "use Test::Perl::Critic";
+plan skip_all => 'Test::Perl::Critic required to criticise code' if $@;
+Test::Perl::Critic->import(-profile => "xt/perlcriticrc");
+all_critic_ok();

--- a/xt/eol.t
+++ b/xt/eol.t
@@ -1,0 +1,7 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+eval 'use Test::EOL';
+plan skip_all => 'Test::EOL required' if $@;
+all_perl_files_ok({ trailing_whitespace => 1 });

--- a/xt/no-tabs.t
+++ b/xt/no-tabs.t
@@ -1,0 +1,7 @@
+#!perl
+use strict;
+use warnings;
+use Test::More;
+eval 'use Test::NoTabs';
+plan skip_all => 'Test::NoTabs required' if $@;
+all_perl_files_ok();

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -1,0 +1,16 @@
+# no strict 'refs'
+[TestingAndDebugging::ProhibitNoStrict]
+allow = refs
+
+[TestingAndDebugging::RequireUseStrict]
+equivalent_modules = Registry::Box::features Registry::Box::Test
+
+[-BuiltinFunctions::ProhibitStringyEval]
+[-ControlStructures::ProhibitMutatingListFunctions]
+[-Subroutines::ProhibitExplicitReturnUndef]
+[-Subroutines::ProhibitSubroutinePrototypes]
+[-Variables::ProhibitConditionalDeclarations]
+
+# for mkdir $dir, 0777
+[-ValuesAndExpressions::ProhibitLeadingZeros]
+

--- a/xt/pod-coverage.t
+++ b/xt/pod-coverage.t
@@ -1,0 +1,9 @@
+#!perl
+use Test::More;
+eval "use Test::Pod::Coverage 1.08";
+plan skip_all => "Test::Pod::Coverage 1.08 required for testing POD coverage"
+  if $@;
+eval "use Pod::Coverage::TrustPod";
+plan skip_all => "Pod::Coverage::TrustPod required for testing POD coverage"
+  if $@;
+all_pod_coverage_ok({ coverage_class => 'Pod::Coverage::TrustPod' });

--- a/xt/pod-spell.t
+++ b/xt/pod-spell.t
@@ -1,0 +1,22 @@
+#!perl
+use Test::More;
+eval "use Pod::Wordlist::hanekomu";
+plan skip_all => "Pod::Wordlist::hanekomu required for testing POD spelling"
+  if $@;
+eval "use Test::Spelling 0.12";
+plan skip_all => "Test::Spelling 0.12 required for testing POD spelling"
+  if $@;
+add_stopwords(<DATA>);
+all_pod_files_spelling_ok('lib');
+__DATA__
+Marcel
+Gruenauer
+Florian
+Helmberger
+Achim
+Adam
+Mark
+Hofstetter
+Heinz
+Ekker
+Reutner

--- a/xt/pod-syntax.t
+++ b/xt/pod-syntax.t
@@ -1,0 +1,5 @@
+#!perl
+use Test::More;
+eval "use Test::Pod 1.41";
+plan skip_all => "Test::Pod 1.41 required for testing POD" if $@;
+all_pod_files_ok();

--- a/xt/synopsis.t
+++ b/xt/synopsis.t
@@ -1,0 +1,6 @@
+#!perl
+use Test::More;
+eval "use Test::Synopsis";
+plan skip_all => "Test::Synopsis required for testing synopses"
+  if $@;
+all_synopsis_ok('lib');

--- a/xt/synopsis.t
+++ b/xt/synopsis.t
@@ -3,4 +3,4 @@ use Test::More;
 eval "use Test::Synopsis";
 plan skip_all => "Test::Synopsis required for testing synopses"
   if $@;
-all_synopsis_ok('lib');
+all_synopsis_ok();

--- a/xt/unused-vars.t
+++ b/xt/unused-vars.t
@@ -1,0 +1,6 @@
+#!perl
+use Test::More;
+eval "use Test::Vars";
+plan skip_all => "Test::Vars required for testing unused vars"
+  if $@;
+all_vars_ok();


### PR DESCRIPTION
Hi. I recently updated Data::Printer to 1.000001 and followed the directions in the documentation to override the debugger's p() command. But when I tried it everything was displayed twice! I had also assumed that I could added options to the config section in .perldb, which was not the case.

I modified DB::Pluggable::Plugin::DataPrinter so it would print out variables only once, and added support for options in the config block. I noticed that github was 1.111751 but CPAN is 1.112001, so I updated that as well.

I didn't update the version number of the module or update the Changes file. I'm not sure what the version number should be, but I would be happy to update my pull request.

Thanks,
Keith Carangelo